### PR TITLE
Adding unit tests for CountryPickerScreen

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,19 +13,19 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="SignUpScreenTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="whenEnteringPhoneAndPassword_ThenButtonIsEnabled()">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
       <SelectionState runConfigName="whenTextFieldsHasValues_thenConfirmButtonIsEnabled()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="whenNameIsNotValid_ThenNameErrorShows()">
+      <SelectionState runConfigName="whenNavigatingToCountryPickerScreen_ThenLoadingIndicatorIsDisplayed()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="whenPhoneIsNotValid_ThenPhoneErrorShows()">
+      <SelectionState runConfigName="whenInternetIsNotConnected_ThenNoInternetViewIsDisplayed()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="whenClickingBack_ThenBackIntentIsFired()">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="whenClickingCountry_ThenCountryIntentIsFired()">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/app/src/androidTest/kotlin/com/example/task_prp/ui/screen/countrypickerScreen/CountryPickerScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/example/task_prp/ui/screen/countrypickerScreen/CountryPickerScreenTest.kt
@@ -1,0 +1,107 @@
+package com.example.task_prp.ui.screen.countrypickerScreen
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.example.task_prp.domain.model.Country
+import com.example.task_prp.ui.screen.signupscreen.SignUpTestTag
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+
+class CountryPickerScreenTest {
+
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun whenNavigatingToCountryPickerScreen_ThenLoadingIndicatorIsDisplayed(){
+        composeTestRule.setContent {
+            ContentChooser(
+                modifier = Modifier,
+                state = CountryPickerContract.CountryPickerState(
+                    isLoading = true,
+                    isInternetConnected = true
+                )
+            ) { }
+        }
+
+        composeTestRule.onNodeWithTag("loadingIndicator").assertExists()
+    }
+
+    @Test
+    fun whenInternetIsNotConnected_ThenNoInternetViewIsDisplayed(){
+        composeTestRule.setContent {
+            ContentChooser(
+                modifier = Modifier,
+                state = CountryPickerContract.CountryPickerState(
+                    isInternetConnected = false,
+                )
+            ) { }
+        }
+
+        composeTestRule.onNodeWithTag("NoInternetView").assertExists()
+    }
+
+
+    @Test
+    fun whenClickingBack_ThenBackIntentIsFired(){
+        var receivedIntent: CountryPickerContract.CountryPickerIntent.OnBackClick? = null
+        composeTestRule.setContent {
+            CountryPickerContent(
+                modifier = Modifier,
+                state = CountryPickerContract.CountryPickerState(
+                )
+            ) { intent ->
+                when(intent){
+                    is CountryPickerContract.CountryPickerIntent.OnBackClick -> {
+                        receivedIntent = intent
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag(SignUpTestTag.BACK_BUTTON_TEST_TAG).performClick()
+        assertThat(receivedIntent).isInstanceOf(CountryPickerContract.CountryPickerIntent.OnBackClick::class.java)
+
+    }
+
+    @Test
+    fun whenClickingCountry_ThenCountryIntentIsFired(){
+        var receivedIntent: CountryPickerContract.CountryPickerIntent.OnCountryClick? = null
+        composeTestRule.setContent {
+            CountryPickerContent(
+                modifier = Modifier,
+                state = CountryPickerContract.CountryPickerState(
+                    countries = listOf(
+                        Country(
+                            "EG",
+                            "20",
+                            "EGYPT",
+                            "\uD83C\uDDE6\uD83C\uDDEA"
+                        )
+                    )
+                )
+            ) { intent ->
+                when(intent){
+                    is CountryPickerContract.CountryPickerIntent.OnCountryClick -> {
+                        receivedIntent = intent
+                    }
+                    else -> {}
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithTag("countryClick").performClick()
+        assertThat(receivedIntent).isInstanceOf(CountryPickerContract.CountryPickerIntent.OnCountryClick::class.java)
+
+    }
+
+
+
+}

--- a/app/src/main/java/com/example/task_prp/ui/common/AppCountryView.kt
+++ b/app/src/main/java/com/example/task_prp/ui/common/AppCountryView.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,11 +29,7 @@ fun AppCountryCode(
     country: Country,
     onCountrySelected:()-> Unit
 ) {
-    Column(
-        Modifier.clickable {
-            onCountrySelected()
-        }
-    ) {
+    Column {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -40,12 +37,12 @@ fun AppCountryCode(
                 .fillMaxWidth()
                 .height(50.dp)
                 .padding(8.dp)
+                .clickable{
+                    onCountrySelected()
+                }
+                .testTag("countryClick")
         ) {
-//            Image(
-//                painter = painterResource(country.icon),
-//                contentDescription = "flag for ${country.countryName}",
-//                modifier = Modifier.padding(8.dp)
-//            )
+
             Text(
                 text = country.icon,
                 fontSize = 25.sp

--- a/app/src/main/java/com/example/task_prp/ui/screen/countrypickerScreen/CountryPickerScreen.kt
+++ b/app/src/main/java/com/example/task_prp/ui/screen/countrypickerScreen/CountryPickerScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -72,7 +73,8 @@ fun ContentChooser(
             ) {
                 CircularProgressIndicator(
                     color = MaterialTheme.colorScheme.primary,
-                    strokeWidth = 4.dp
+                    strokeWidth = 4.dp,
+                    modifier = Modifier.testTag("loadingIndicator")
                 )
             }
         }
@@ -99,12 +101,13 @@ fun CountryPickerContent(
             setIntent(CountryPickerContract.CountryPickerIntent.OnBackClick(state.selectedCountryCode))
         }
 
-        LazyColumn {
+        LazyColumn(
+            Modifier.testTag("scroll")
+        ) {
             items(state.countries){ country ->
                 AppCountryCode(country = country){
                     val countryId = country.countryCode
                     setIntent(CountryPickerContract.CountryPickerIntent.OnCountryClick(countryId))
-
                 }
             }
         }
@@ -114,7 +117,7 @@ fun CountryPickerContent(
 @Composable
 fun NoInternetView(modifier: Modifier = Modifier) {
     Column(
-        modifier.fillMaxSize(),
+        modifier.fillMaxSize().testTag("NoInternetView"),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -128,7 +131,7 @@ fun NoInternetView(modifier: Modifier = Modifier) {
         )
 
         Text(
-            "The internet is not connected",
+            "internet is not connected",
             fontSize = 16.sp,
             color = Color.Red
         )


### PR DESCRIPTION
This commit introduces unit tests for the `CountryPickerScreen` to verify its behavior under different conditions:

-   Ensures the loading indicator is displayed when `isLoading` is true.
-   Confirms the "No Internet" view is shown when `isInternetConnected` is false.
-   Verifies that the `OnBackClick` intent is fired when the back button is clicked.
-   Checks that the `OnCountryClick` intent is fired when a country is selected.